### PR TITLE
Implement Customizable Recomposition Frequency

### DIFF
--- a/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/Kubriko.kt
+++ b/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/Kubriko.kt
@@ -11,6 +11,7 @@ package com.pandulapeter.kubriko
 
 import com.pandulapeter.kubriko.Kubriko.Companion.newInstance
 import com.pandulapeter.kubriko.manager.Manager
+import com.pandulapeter.kubriko.types.FrameRate
 import kotlin.reflect.KClass
 
 /**
@@ -49,5 +50,7 @@ sealed interface Kubriko {
             isLoggingEnabled = isLoggingEnabled,
             instanceNameForLogging = instanceNameForLogging,
         )
+
+        var frameRate = FrameRate.Normal
     }
 }

--- a/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/implementation/InternalViewport.kt
+++ b/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/implementation/InternalViewport.kt
@@ -59,16 +59,20 @@ fun InternalViewport(
     // Game loop
     LaunchedEffect(Unit) {
         kubrikoImpl.initialize()
+        var count = 0
         while (isActive) {
             withFrameMillis { frameTimeInMilliseconds ->
                 if (kubrikoImpl.metadataManager.totalRuntimeInMilliseconds.value == 0L) {
                     kubrikoImpl.metadataManager.onUpdateInternal(frameTimeInMilliseconds.toInt())
                 }
-                (frameTimeInMilliseconds - kubrikoImpl.metadataManager.totalRuntimeInMilliseconds.value).toInt().let { deltaTimeInMilliseconds ->
-                    if (!kubrikoImpl.viewportManager.size.value.isEmpty() && kubrikoImpl.stateManager.isFocused.value) {
-                        kubrikoImpl.managers.forEach { it.onUpdateInternal(deltaTimeInMilliseconds) }
+                if (count % Kubriko.frameRate.factor == 0) {
+                    (frameTimeInMilliseconds - kubrikoImpl.metadataManager.totalRuntimeInMilliseconds.value).toInt().let { deltaTimeInMilliseconds ->
+                        if (!kubrikoImpl.viewportManager.size.value.isEmpty() && kubrikoImpl.stateManager.isFocused.value) {
+                            kubrikoImpl.managers.forEach { it.onUpdateInternal(deltaTimeInMilliseconds) }
+                        }
                     }
                 }
+                count++
             }
         }
     }

--- a/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/types/FrameRate.kt
+++ b/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/types/FrameRate.kt
@@ -1,0 +1,7 @@
+package com.pandulapeter.kubriko.types
+
+enum class FrameRate(val factor: Int) {
+    Normal(1),
+    Half(2),
+    Quarter(4)
+}


### PR DESCRIPTION
1. Feature

This Pull Request introduces a new FrameRate enum class, allowing developers to specify the recomposition frequency within the Kubriko engine. Three default options are currently provided:

Normal: Recomposes at the normal frame rate (defaulting to the device's refresh rate, typically around 60 FPS).
Half: Reduces the recomposition frequency to half of the normal rate.
Quarter: Reduces the recomposition frequency to a quarter of the normal rate.
Additionally, the execution frequency of the logic update within the engine's update loop is now influenced by Kubriko.frameRate.factor. This means that when FrameRate is set to Half, the logic update will execute every other frame; when set to Quarter, it will execute every fourth frame.

2. Purpose

The purpose of introducing this feature is to provide a simple and effective way to reduce the application's power consumption. By lowering the recomposition and logic update frequencies, the utilization of the CPU and GPU can be decreased, potentially extending battery life and improving performance on lower-end devices.

This change is particularly applicable to game scenarios where immediate responsiveness is not critical or where visual changes are infrequent. Developers can flexibly adjust the recomposition frequency based on specific game requirements and performance targets.

3. Suggestions for Modification or Cancellation

Important Note Regarding FPS Calculation: The current FPS calculation in the engine relies on the highest possible recomposition speed. This modification does not alter the FPS calculation. Therefore, when a lower FrameRate is selected, the reported FPS may not accurately reflect the actual visual update frequency, potentially leading to a misleading FPS value.

Please feel free to modify or cancel this Pull Request as you see fit. Thank you for your review.