### PR TITLE
Bug fix for kubriko showcase app not filling the web browser window w…

### DIFF
--- a/app/src/webMain/resources/index.html
+++ b/app/src/webMain/resources/index.html
@@ -40,8 +40,9 @@
         }(window.location))
     </script>
     <style>
-        body {
+        html, body {
             margin: 0;
+            height: 100%;
             overflow: hidden;
         }
 


### PR DESCRIPTION
This is a very small change that fix a bug of the kubriko showcase app filling only a very small part of the web browser window height, when running it on the wasm/js target