### PR TITLE
Adjustment to ordering of Group actor add/remove

### DIFF
--- a/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/manager/ActorManagerImpl.kt
+++ b/engine/src/commonMain/kotlin/com/pandulapeter/kubriko/manager/ActorManagerImpl.kt
@@ -150,7 +150,10 @@ internal class ActorManagerImpl(
     }
 
     private fun flattenActors(actors: List<Actor>): List<Actor> = actors.flatMap { actor ->
-        if (actor is Group) flattenActors(actor.actors.filterNot { it === actor }) + actor
+        if (actor is Group) buildList {
+            add(actor)
+            addAll(flattenActors(actor.actors.filterNot { it === actor }))
+        }
         else listOf(actor)
     }
 
@@ -170,7 +173,7 @@ internal class ActorManagerImpl(
 
     override fun remove(vararg actors: Actor) {
         if (actors.isNotEmpty()) {
-            val flattenedActors = flattenActors(actors.toList())
+            val flattenedActors = flattenActors(actors.toList()).asReversed()
             _allActors.update { currentActors ->
                 currentActors.filterNot { it in flattenedActors }.toImmutableList()
             }


### PR DESCRIPTION
Changed handling of adding and removing grouped actors so the parent is added first and removed last.

The principle here being that children should not be present without their parent. 

This allows children to reference the parent in `onAdded()` and be able to assume that the parent has already had `onAdded()` invoked on it. This is important if children need to derive properties from their parent, which in turn are based on properties that require the Kubriko instance, eg sprite dimensions.